### PR TITLE
truncate length of title

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,12 @@
                 "type": "string",
                 "default": "assignee = currentUser() ORDER BY updated DESC",
                 "description": "JQL query to fetch issues"
+            },
+            "jira-sidekick.maxTabTitleLength": {
+                "type": "number",
+                "default": 30,
+                "scope": "window",
+                "description": "Maximum number of characters to display for issue summaries in editor tab titles. Set to 0 to disable truncation."
             }
         }
     }

--- a/src/ui/issuePanel.ts
+++ b/src/ui/issuePanel.ts
@@ -68,12 +68,21 @@ export class IssuePanel {
         try {
             const issue = await this.client.getIssue(issueKey);
             this.currentIssue = issue;
-            this.panel.title = `${issue.key}: ${issue.fields.summary}`;
+            const maxLength = vscode.workspace.getConfiguration('jira-sidekick').get<number>('maxTabTitleLength', 30);
+            const truncatedSummary = this.truncateText(issue.fields.summary, maxLength);
+            this.panel.title = `${issue.key}: ${truncatedSummary}`;
             this.panel.webview.html = this.getIssueContent(issue);
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             this.panel.webview.html = this.getErrorContent(issueKey, message);
         }
+    }
+
+    private truncateText(text: string, maxLength: number): string {
+        if (maxLength <= 0 || text.length <= maxLength) {
+            return text;
+        }
+        return text.slice(0, maxLength) + '...';
     }
 
     private getLoadingContent(issueKey: string): string {


### PR DESCRIPTION
close https://github.com/TommyWoodley/jira-sidekick/issues/1

- Places a limit by default 30 characters of the text and also allows it to be configurable