### PR TITLE
Add attachment support to Jira issues

### DIFF
--- a/src/jira/client.ts
+++ b/src/jira/client.ts
@@ -166,7 +166,7 @@ export class JiraClient {
 
         const { baseUrl, email, apiToken } = credentials;
         const url = new URL(`/rest/api/3/issue/${issueKey}`, baseUrl);
-        url.searchParams.set('fields', 'summary,status,assignee,reporter,priority,issuetype,created,updated,labels,description');
+        url.searchParams.set('fields', 'summary,status,assignee,reporter,priority,issuetype,created,updated,labels,description,attachment');
         const authHeader = Buffer.from(`${email}:${apiToken}`).toString('base64');
 
         const response = await fetch(url.toString(), {

--- a/src/jira/types.ts
+++ b/src/jira/types.ts
@@ -33,6 +33,15 @@ export interface JiraIssueType {
     iconUrl?: string;
 }
 
+export interface JiraAttachment {
+    id: string;
+    filename: string;
+    mimeType: string;
+    size: number;
+    content: string;
+    created: string;
+}
+
 export interface JiraIssue {
     id: string;
     key: string;
@@ -48,6 +57,7 @@ export interface JiraIssue {
         updated: string;
         description?: unknown;
         labels?: string[];
+        attachment?: JiraAttachment[];
     };
 }
 

--- a/src/ui/issuePanel.ts
+++ b/src/ui/issuePanel.ts
@@ -32,6 +32,11 @@ export class IssuePanel {
                             this.onOpenInBrowser(this.currentIssue);
                         }
                         break;
+                    case 'openAttachment':
+                        if (message.url) {
+                            vscode.env.openExternal(vscode.Uri.parse(message.url));
+                        }
+                        break;
                 }
             },
             null,

--- a/src/webview-ui/shared/types.ts
+++ b/src/webview-ui/shared/types.ts
@@ -10,6 +10,15 @@ export interface JiraFilter {
   favourite: boolean;
 }
 
+export interface JiraAttachment {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  content: string;
+  created: string;
+}
+
 export interface JiraIssue {
   key: string;
   fields: {
@@ -31,6 +40,7 @@ export interface JiraIssue {
       name: string;
     } | null;
     labels: string[];
+    attachment?: JiraAttachment[];
   };
 }
 


### PR DESCRIPTION
- Updated JiraClient to include 'attachment' field in issue retrieval.
- Introduced JiraAttachment interface to define attachment properties.
- Enhanced IssuePanel to handle opening attachments.
- Updated IssueApp to display attachments with appropriate UI elements and file type icons.

Closes https://github.com/TommyWoodley/jira-sidekick/issues/5