### PR TITLE
Add functionality to download and save attachments in Jira issues

### DIFF
--- a/src/jira/client.ts
+++ b/src/jira/client.ts
@@ -195,5 +195,29 @@ export class JiraClient {
 
         return await response.json() as JiraIssue;
     }
+
+    async downloadAttachment(contentUrl: string): Promise<Buffer> {
+        const credentials = await this.authService.getCredentials();
+        if (!credentials) {
+            throw new JiraClientError('No credentials configured');
+        }
+
+        const { email, apiToken } = credentials;
+        const authHeader = Buffer.from(`${email}:${apiToken}`).toString('base64');
+
+        const response = await fetch(contentUrl, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Basic ${authHeader}`,
+            }
+        });
+
+        if (!response.ok) {
+            throw new JiraClientError(`Failed to download attachment: ${response.status}`, response.status);
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        return Buffer.from(arrayBuffer);
+    }
 }
 

--- a/src/webview-ui/issue/issue-app.ts
+++ b/src/webview-ui/issue/issue-app.ts
@@ -334,6 +334,18 @@ export class IssueApp extends LitElement {
     postMessage({ command: 'openAttachment', url: attachment.content });
   }
 
+  private handleSaveAttachment(e: MouseEvent, attachment: JiraAttachment) {
+    e.preventDefault();
+    postMessage({
+      command: 'saveAttachment',
+      attachment: {
+        id: attachment.id,
+        filename: attachment.filename,
+        content: attachment.content
+      }
+    });
+  }
+
   render() {
     if (this.isLoading) {
       return html`
@@ -439,7 +451,8 @@ export class IssueApp extends LitElement {
               <div 
                 class="attachment-item" 
                 @click=${() => this.handleOpenAttachment(attachment)}
-                title="Click to open in browser"
+                @contextmenu=${(e: MouseEvent) => this.handleSaveAttachment(e, attachment)}
+                title="Click to open • Right-click to save to workspace"
               >
                 <span class="attachment-icon">${this.getFileTypeIcon(attachment.mimeType)}</span>
                 <span class="attachment-name">${attachment.filename}</span>


### PR DESCRIPTION
- Implemented downloadAttachment method in JiraClient to fetch attachments.
- Enhanced IssuePanel to handle saveAttachment command and manage file saving.
- Updated IssueApp to trigger saveAttachment on right-clicking attachment items.