### PR TITLE
Enhance issue rendering by prefetching images from ADF media nodes

### DIFF
--- a/src/webview-ui/issue/issue-app.ts
+++ b/src/webview-ui/issue/issue-app.ts
@@ -218,6 +218,7 @@ export class IssueApp extends LitElement {
   @state() private isLoading = true;
   @state() private error: { issueKey: string; message: string } | null = null;
   @state() private loadingIssueKey = '';
+  @state() private imageMap: Record<string, string> = {};
 
   connectedCallback() {
     super.connectedCallback();
@@ -240,6 +241,7 @@ export class IssueApp extends LitElement {
       case 'loadIssue':
         this.isLoading = false;
         this.issue = message.issue;
+        this.imageMap = message.imageMap || {};
         this.error = null;
         break;
       case 'error':
@@ -386,8 +388,8 @@ export class IssueApp extends LitElement {
         <div class="section-title">Description</div>
         <div class="description-container">
           ${this.issue.fields.description
-        ? html`<adf-renderer .adf=${this.issue.fields.description}></adf-renderer>`
-        : html`<span class="no-description">No description</span>`}
+            ? html`<adf-renderer .adf=${this.issue.fields.description} .imageMap=${this.imageMap}></adf-renderer>`
+            : html`<span class="no-description">No description</span>`}
         </div>
 
         ${this.renderAttachments()}

--- a/src/webview-ui/shared/adf-renderer.ts
+++ b/src/webview-ui/shared/adf-renderer.ts
@@ -179,6 +179,14 @@ export class AdfRenderer extends LitElement {
       margin: 4px 0;
     }
 
+    .inline-image {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+      margin: 8px 0;
+      display: block;
+    }
+
     .inline-card {
       display: inline-flex;
       align-items: center;
@@ -195,6 +203,7 @@ export class AdfRenderer extends LitElement {
   `;
 
   @property({ type: Object }) adf: AdfNode | null = null;
+  @property({ type: Object }) imageMap: Record<string, string> = {};
 
   render() {
     if (!this.adf) {
@@ -261,9 +270,17 @@ export class AdfRenderer extends LitElement {
       case 'tableCell':
         return html`<td>${node.content?.map(child => this.renderNode(child))}</td>`;
 
-      case 'mediaSingle':
-      case 'media':
+      case 'mediaSingle': {
+        // mediaSingle contains a media child node
+        const mediaChild = node.content?.find(n => n.type === 'media');
+        if (mediaChild) {
+          return this.renderMediaNode(mediaChild);
+        }
         return html`<div class="media-placeholder">📎 Media attachment</div>`;
+      }
+
+      case 'media':
+        return this.renderMediaNode(node);
 
       case 'panel': {
         const panelType = (node.attrs?.panelType as string) || 'info';
@@ -310,6 +327,14 @@ export class AdfRenderer extends LitElement {
         }
         return nothing;
     }
+  }
+
+  private renderMediaNode(node: AdfNode): TemplateResult {
+    const id = node.attrs?.id as string;
+    if (id && this.imageMap[id]) {
+      return html`<img src="${this.imageMap[id]}" class="inline-image" alt="Image" />`;
+    }
+    return html`<div class="media-placeholder">📎 Media attachment</div>`;
   }
 
   private renderChildren(node: AdfNode): TemplateResult | string {


### PR DESCRIPTION
- Implemented methods to extract media information and build attachment maps.
- Added functionality to prefetch images and pass them to the webview.
- Updated the IssuePanel to include an image map in the message sent to the webview.
- Modified the AdfRenderer to render images inline using the provided image map.