### PR TITLE
Add image loading functionality to IssuePanel and ADF renderer

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -46,5 +46,7 @@ export interface IssueApi {
         filename: string;
         content: string;
     }): Promise<void>;
+
+    loadImage(id: string): Promise<string | null>;
 }
 


### PR DESCRIPTION
- Introduced a new method in the IssueApi to load images by ID.
- Updated IssuePanel to manage image loading and mapping, replacing the previous media extraction logic.
- Enhanced the ADF renderer with lazy loading for images, improving performance and user experience.
- Added skeleton loaders for images while they are being fetched, ensuring a smoother UI transition.

Closes https://github.com/TommyWoodley/jira-sidekick/issues/15