### PR TITLE
Refactor openInBrowser method in CommandsManager to be asynchronous and enhance functionality

### DIFF
--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -109,24 +109,34 @@ suite('CommandsManager Test Suite', () => {
     });
 
     suite('openInBrowser()', () => {
-        test('does nothing when issue is null', () => {
-            commandsManager.openInBrowser(null as unknown as JiraIssue);
+        test('does nothing when issue is null', async () => {
+            await commandsManager.openInBrowser(null as unknown as JiraIssue);
         });
 
-        test('does nothing when issue is undefined', () => {
-            commandsManager.openInBrowser(undefined as unknown as JiraIssue);
+        test('does nothing when issue is undefined', async () => {
+            await commandsManager.openInBrowser(undefined as unknown as JiraIssue);
         });
 
-        test('opens browser with valid issue', () => {
-            commandsManager.openInBrowser(mockIssue);
+        test('does nothing when no credentials', async () => {
+            await commandsManager.openInBrowser(mockIssue);
         });
 
-        test('opens browser with issue having different self URL format', () => {
-            const issueWithDifferentUrl: JiraIssue = {
-                ...mockIssue,
-                self: 'https://test.atlassian.net/rest/api/3/issue/12345',
-            };
-            commandsManager.openInBrowser(issueWithDifferentUrl);
+        test('opens browser with valid issue and credentials', async () => {
+            await authService.setCredentials({
+                baseUrl: 'https://test.atlassian.net',
+                email: 'test@example.com',
+                apiToken: 'test-token',
+            });
+            await commandsManager.openInBrowser(mockIssue);
+        });
+
+        test('constructs correct URL from baseUrl and issue key', async () => {
+            await authService.setCredentials({
+                baseUrl: 'https://custom-jira.example.com',
+                email: 'test@example.com',
+                apiToken: 'test-token',
+            });
+            await commandsManager.openInBrowser(mockIssue);
         });
     });
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -113,11 +113,15 @@ export class CommandsManager {
         );
     }
 
-    openInBrowser(issue: JiraIssue): void {
+    async openInBrowser(issue: JiraIssue): Promise<void> {
         if (!issue) {
             return;
         }
-        const url = issue.self.replace('/rest/api/3/issue/', '/browse/').replace(/\/\d+$/, `/${issue.key}`);
+        const credentials = await this.authService.getCredentials();
+        if (!credentials) {
+            return;
+        }
+        const url = `${credentials.baseUrl}/browse/${issue.key}`;
         vscode.env.openExternal(vscode.Uri.parse(url));
     }
 
@@ -130,7 +134,7 @@ export class CommandsManager {
             this.client,
             issue.key,
             issue.fields.summary,
-            (i) => this.openInBrowser(i)
+            async (i) => this.openInBrowser(i)
         );
     }
 
@@ -143,7 +147,7 @@ export class CommandsManager {
             this.client,
             issue.key,
             issue.fields.summary,
-            (i) => this.openInBrowser(i)
+            async (i) => this.openInBrowser(i)
         );
     }
 


### PR DESCRIPTION
- Updated openInBrowser to handle null and undefined issues gracefully.
- Added credential checks before opening the browser.
- Constructed the correct URL using baseUrl and issue key.
- Updated related tests to reflect the new asynchronous behavior and added additional test cases for credential handling.

Closes https://github.com/TommyWoodley/jira-sidekick/issues/20